### PR TITLE
require less privileges for certain commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ these deviations:
 ### Changed
 
 - [Moved the `completion` subcommand into the `emit` subcommand](https://github.com/TeFiLeDo/nimo/pull/2)
+- [Subcommands that don't change the data will now run without write access to the data file](https://github.com/TeFiLeDo/nimo/pull/3)
 
 [unreleased]: https://github.com/TeFiLeDo/nimo/compare/v0.1.0...HEAD
 


### PR DESCRIPTION
With this changes, certain commands will require way less privileges to run successfully.

1. The `emit` command will now be executed before loading the data file.
2. All commands except `ping` and `speed-test` will no longer require write access to the data file, as they won't modify it anyways.