### PR TITLE
automatically retry speed tests up to five times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ these deviations:
 ### Added
 
 - [Started a changelog at `CHANGELOG.md`](https://github.com/TeFiLeDo/nimo/pull/1)
+- [The `speed-test` subcommand now automatically retries up to five times if a test results in an error](https://github.com/TeFiLeDo/nimo/pull/4)
 
 ### Changed
 

--- a/src/speedtest/cmd.rs
+++ b/src/speedtest/cmd.rs
@@ -19,61 +19,69 @@ impl Command {
             return Ok(None);
         }
 
-        debug!("running test");
-        let output = match Cmd::new("speedtest").arg("--format").arg("json").output() {
-            Ok(x) => x,
-            Err(e) => {
-                if let NotFound = e.kind() {
-                    return Err(anyhow!(r#""speedtest" command not found"#));
+        for i in 0..5 {
+            debug!("running test attempt {}", i);
+            let output = match Cmd::new("speedtest").arg("--format").arg("json").output() {
+                Ok(x) => x,
+                Err(e) => {
+                    if let NotFound = e.kind() {
+                        return Err(anyhow!(r#""speedtest" command not found"#));
+                    } else {
+                        return Err(e).context("failed to run speedtest cli");
+                    }
+                }
+            };
+
+            debug!("deserializing output");
+            let val: Value =
+                from_slice(&output.stdout).context("failed to parse deserialize output")?;
+
+            debug!("parsing output");
+            if let Some(str) = val["error"].as_str() {
+                if i == 4 {
+                    return Err(anyhow!(str.to_owned())).context("failed to run speed test");
                 } else {
-                    return Err(e).context("failed to run speedtest cli");
+                    continue;
                 }
             }
-        };
 
-        debug!("deserializing output");
-        let val: Value =
-            from_slice(&output.stdout).context("failed to parse deserialize output")?;
-
-        debug!("parsing output");
-        if let Some(str) = val["error"].as_str() {
-            return Err(anyhow!(str.to_owned())).context("failed to run speed test");
+            // server
+            return Ok(Some(super::Data {
+                server_id: val["server"]["id"]
+                    .as_u64()
+                    .ok_or(anyhow!(DT))
+                    .context(CT)?,
+                server_host: val["server"]["host"]
+                    .as_str()
+                    .ok_or(anyhow!(DT))
+                    .context(CT)?
+                    .to_owned(),
+                server_name: val["server"]["name"]
+                    .as_str()
+                    .ok_or(anyhow!(DT))
+                    .context(CT)?
+                    .to_owned(),
+                server_country: val["server"]["country"]
+                    .as_str()
+                    .ok_or(anyhow!(DT))
+                    .context(CT)?
+                    .to_owned(),
+                isp: val["isp"]
+                    .as_str()
+                    .ok_or(anyhow!(DT))
+                    .context(CT)?
+                    .to_owned(),
+                upload: val["upload"]["bandwidth"]
+                    .as_u64()
+                    .ok_or(anyhow!(DT))
+                    .context(CT)?,
+                download: val["download"]["bandwidth"]
+                    .as_u64()
+                    .ok_or(anyhow!(DT))
+                    .context(CT)?,
+            }));
         }
 
-        // server
-        Ok(Some(super::Data {
-            server_id: val["server"]["id"]
-                .as_u64()
-                .ok_or(anyhow!(DT))
-                .context(CT)?,
-            server_host: val["server"]["host"]
-                .as_str()
-                .ok_or(anyhow!(DT))
-                .context(CT)?
-                .to_owned(),
-            server_name: val["server"]["name"]
-                .as_str()
-                .ok_or(anyhow!(DT))
-                .context(CT)?
-                .to_owned(),
-            server_country: val["server"]["country"]
-                .as_str()
-                .ok_or(anyhow!(DT))
-                .context(CT)?
-                .to_owned(),
-            isp: val["isp"]
-                .as_str()
-                .ok_or(anyhow!(DT))
-                .context(CT)?
-                .to_owned(),
-            upload: val["upload"]["bandwidth"]
-                .as_u64()
-                .ok_or(anyhow!(DT))
-                .context(CT)?,
-            download: val["download"]["bandwidth"]
-                .as_u64()
-                .ok_or(anyhow!(DT))
-                .context(CT)?,
-        }))
+        panic!("speedtest neither succeeded nor aborted after fifth failure");
     }
 }


### PR DESCRIPTION
This makes it so, that the `speed-test` command automatically retries executing the actual speed test if it failed.

This will help mitigate the fact, that with some speed test server the upload fails every time (eg. 12390 of A1 Telekom Austria AG).