### PR TITLE
enable users to accept speedtest.net eula

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ these deviations:
 
 - [Moved the `completion` subcommand into the `emit` subcommand](https://github.com/TeFiLeDo/nimo/pull/2)
 - [Subcommands that don't change the data will now run without write access to the data file](https://github.com/TeFiLeDo/nimo/pull/3)
+- [Enable useres to accept the eula of the speedtest cli](https://github.com/TeFiLeDo/nimo/pull/5)
 
 [unreleased]: https://github.com/TeFiLeDo/nimo/compare/v0.1.0...HEAD
 

--- a/systemd/nimo-speed-test.service
+++ b/systemd/nimo-speed-test.service
@@ -4,3 +4,4 @@ Description=running ping test
 [Service]
 Type=oneshot
 ExecStart=/usr/local/bin/nimo speed-test
+User=root


### PR DESCRIPTION
This makes it possible for users to accept the eula of [the speedtest cli](https://speedtest.net), which is used internally. For some reason, if the user isn't explicitly specified, the cli fails to perform.