### PR TITLE
add a `report` subcommand for simple data evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ these deviations:
 
 ## [Unreleased]
 
+### Added
+
+- [A new `report` subcommand that prints a few stats to the command line](https://github.com/TeFiLeDo/nimo/pull/8)
+
 [unreleased]: https://github.com/TeFiLeDo/nimo/compare/v0.2.0...HEAD
 
 ## [0.2.0]: Buzzing Bumblebee - 2020-04-25

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ mod config;
 mod data;
 mod emit;
 mod ping;
+mod report;
 mod speedtest;
 
 use config::Config;
@@ -37,6 +38,7 @@ struct Opt {
 enum Command {
     Emit(emit::Command),
     Ping(ping::Command),
+    Report(report::Command),
     SpeedTest(speedtest::Command),
 }
 
@@ -78,6 +80,7 @@ async fn main() -> Result<()> {
 
             data.pings.insert(now, res);
         }
+        Command::Report(c) => c.execute(&mut data).context("failed to execute report")?,
         Command::SpeedTest(s) => {
             let res = s
                 .execute(&config.speed_test)
@@ -122,7 +125,7 @@ fn load_data(config: &Config, allow_write: bool) -> Result<(Data, File)> {
     let file = OpenOptions::new()
         .read(true)
         .write(allow_write)
-        .create(true)
+        .create(allow_write)
         .open(&config.data)
         .context("failed to open data file")?;
 

--- a/src/report/command.rs
+++ b/src/report/command.rs
@@ -1,0 +1,95 @@
+use std::collections::BTreeMap;
+
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+
+#[derive(Debug, structopt::StructOpt)]
+pub struct Command {
+    /// Classify ping tests either as success or failure instead of a spectrum.
+    ///
+    /// Without this option, the reliability is the ratio of received responses to sent requests.
+    ///
+    /// With this option, the reliability is the ratio of ping test where at least one target sent
+    /// at least one response to all ping test.
+    #[structopt(short, long)]
+    clearcut: bool,
+}
+
+impl Command {
+    pub fn execute(&self, data: &mut crate::Data) -> Result<()> {
+        let reliability = match if !self.clearcut {
+            get_reliability(&data.pings)
+        } else {
+            get_clearcut_reliability(&data.pings)
+        } {
+            Some(r) => format!("{}%", r * 100.0),
+            None => "no measurements".into(),
+        };
+
+        let (down, up) = match get_avg_speeds(&data.speed_tests) {
+            Some((down, up)) => (down.to_string(), up.to_string()),
+            None => ("no measurements".into(), "no measurements".into()),
+        };
+
+        println!(
+            "reliability:      {}\naverage download: {}\naverage upload:   {}",
+            reliability, down, up
+        );
+
+        Ok(())
+    }
+}
+
+fn get_reliability(data: &BTreeMap<DateTime<Utc>, crate::ping::Data>) -> Option<f64> {
+    let mut sent = 0;
+    let mut received = 0;
+
+    for (_, targets) in data {
+        for target in targets {
+            sent += target.sent;
+            received += target.received
+        }
+    }
+
+    if sent > 0 {
+        Some(received as f64 / sent as f64)
+    } else {
+        None
+    }
+}
+
+fn get_clearcut_reliability(data: &BTreeMap<DateTime<Utc>, crate::ping::Data>) -> Option<f64> {
+    let mut successes = 0;
+
+    'd: for (_, targets) in data {
+        for target in targets {
+            if target.received > 0 {
+                successes += 1;
+                continue 'd;
+            }
+        }
+    }
+
+    if data.len() > 0 {
+        Some(successes as f64 / data.len() as f64)
+    } else {
+        None
+    }
+}
+
+fn get_avg_speeds(data: &BTreeMap<DateTime<Utc>, crate::speedtest::Data>) -> Option<(f64, f64)> {
+    if data.len() == 0 {
+        return None;
+    }
+
+    let mut up = 0;
+    let mut down = 0;
+
+    for (_, test) in data {
+        up += test.upload;
+        down += test.download;
+    }
+
+    let num = data.len() as f64;
+    Some((down as f64 / num, up as f64 / num))
+}

--- a/src/report/command.rs
+++ b/src/report/command.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use chrono::{DateTime, Utc};
 
 #[derive(Debug, structopt::StructOpt)]
+/// Prints a few simple evaluations to the command line.
 pub struct Command {
     /// Classify ping tests either as success or failure instead of a spectrum.
     ///

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -1,0 +1,3 @@
+mod command;
+
+pub use command::Command;


### PR DESCRIPTION
This adds a new `report` subcommand that allows users to evaluate their recorded data on the command line.

This will be followed up with a `present` subcommand, that will feature much more detailed data evaluation with a statically generated webpage.