### PR TITLE
allow users to choose the number of retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ these deviations:
 ### Added
 
 - [A new `report` subcommand that prints a few stats to the command line](https://github.com/TeFiLeDo/nimo/pull/8)
+- [Users can now configure the number of retries to do if a speedtest fails](https://github.com/TeFiLeDo/nimo/pull/9)
 
 [unreleased]: https://github.com/TeFiLeDo/nimo/compare/v0.2.0...HEAD
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ google = "8.8.8.8"
 
 [speed_test]
 enabled = false # if you want to run speed tests, set this to true
+retries = 4
 ```
 
 ## Usage

--- a/src/speedtest/cmd.rs
+++ b/src/speedtest/cmd.rs
@@ -19,7 +19,7 @@ impl Command {
             return Ok(None);
         }
 
-        for i in 0..5 {
+        for i in 0..(config.retries + 1) {
             debug!("running test attempt {}", i);
             let output = match Cmd::new("speedtest").arg("--format").arg("json").output() {
                 Ok(x) => x,

--- a/src/speedtest/config.rs
+++ b/src/speedtest/config.rs
@@ -2,14 +2,21 @@
 pub struct Config {
     #[serde(default = "default_enabled")]
     pub enabled: bool,
+    #[serde(default = "default_retries")]
+    pub retries: u8,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
             enabled: default_enabled(),
+            retries: default_retries(),
         }
     }
+}
+
+fn default_retries() -> u8 {
+    4
 }
 
 fn default_enabled() -> bool {


### PR DESCRIPTION
This adds a new configuration option that allows users to configure the number of retries if a speed test fails.